### PR TITLE
ci: 通过 GitHub Pages 发布可访问的静态站点

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,62 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - name: Resolve Pages base path
+        id: base
+        run: |
+          name="${GITHUB_REPOSITORY#*/}"
+          owner="${GITHUB_REPOSITORY_OWNER}"
+          if [ -n "${PAGES_BASE_PATH}" ]; then
+            echo "path=${PAGES_BASE_PATH}" >> "$GITHUB_OUTPUT"
+          elif [ "$name" = "${owner}.github.io" ]; then
+            echo "path=/" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=/${name}/" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          PAGES_BASE_PATH: ${{ vars.PAGES_BASE_PATH }}
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run build
+        env:
+          BASE_PATH: ${{ steps.base.outputs.path }}
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -82,6 +82,34 @@ npm run preview
 
 生产文件输出到 `dist/`，可以交给静态 HTTP 服务托管。请通过服务地址访问，不要直接双击 `dist/index.html`。
 
+### 在线访问（GitHub Pages）
+
+本仓库通过 GitHub Actions 构建静态站点，并部署到 GitHub Pages。访问者不需要下载源码或在本机启动开发服务器。
+
+首次启用：
+
+1. 打开仓库 **Settings → Pages**，将 **Source** 设为 **GitHub Actions**。
+2. 推送到默认分支 `main`，或在 **Actions** 中手动运行 **Deploy GitHub Pages**。
+
+部署完成后的地址：
+
+- 项目站（仓库名不是 `用户名.github.io`）：`https://<owner>.github.io/<repo>/`，例如 `https://lbeilc.github.io/RhineLabUI/`
+- 用户 / 组织站（仓库名为 `<owner>.github.io`）：`https://<owner>.github.io/`
+
+构建会按仓库名自动加上子路径，让字体、GLB 模型和档案导出在 Pages 上也能加载。若站点挂在自定义域名的根路径，可在仓库 **Settings → Secrets and variables → Actions → Variables** 中设置 `PAGES_BASE_PATH` 为 `/`。
+
+本地可用同一套子路径做对照：
+
+```sh
+# Windows PowerShell
+$env:BASE_PATH="/RhineLabUI/"; npm run build; $env:BASE_PATH="/RhineLabUI/"; npm run preview
+
+# Unix
+BASE_PATH=/RhineLabUI/ npm run build && BASE_PATH=/RhineLabUI/ npm run preview
+```
+
+然后打开终端显示的地址，通常为 `http://127.0.0.1:4173/RhineLabUI/`。
+
 ## 操作说明
 
 ### 终端与档案

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       content="Rhine Lab — Synthesize Information Analysis OS. 交互式三维研究档案终端。"
     />
     <title>RHINE LAB · ANALYSIS OS</title>
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="./favicon.svg" />
   </head>
   <body>
     <main id="viewport"><div id="stage"></div></main>

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,12 +1,32 @@
 export class TerminalAudio {
-  enabled = false;
+  private _enabled = false;
   private context?: AudioContext;
-  play(type: "tick" | "open" | "confirm" | "back" = "tick") {
-    if (!this.enabled) return;
+  private bedGain?: GainNode;
+  private bedOscillators: OscillatorNode[] = [];
+
+  get enabled() {
+    return this._enabled;
+  }
+
+  set enabled(value: boolean) {
+    this._enabled = value;
+    if (this.context) this.syncBed();
+  }
+
+  prime() {
     try {
-      this.context ??= new AudioContext();
-      const c = this.context;
-      if (c.state === "suspended") void c.resume();
+      this.ensureContext();
+      this.syncBed();
+    } catch {
+      /* Audio is optional; the terminal remains fully interactive. */
+    }
+  }
+
+  play(type: "tick" | "open" | "confirm" | "back" = "tick") {
+    if (!this._enabled) return;
+    try {
+      const c = this.ensureContext();
+      this.syncBed();
       const osc = c.createOscillator(),
         gain = c.createGain();
       osc.type = "sine";
@@ -26,5 +46,57 @@ export class TerminalAudio {
     } catch {
       /* Audio is optional; the terminal remains fully interactive. */
     }
+  }
+
+  private ensureContext() {
+    this.context ??= new AudioContext();
+    if (this.context.state === "suspended") void this.context.resume();
+    return this.context;
+  }
+
+  private syncBed() {
+    if (!this.context) return;
+    if (!this._enabled) {
+      this.setBedLevel(0.0001, 0.4);
+      return;
+    }
+    this.ensureBed();
+    this.setBedLevel(1, 1.8);
+  }
+
+  private ensureBed() {
+    if (this.bedGain || !this.context) return;
+    const c = this.context;
+    const master = c.createGain();
+    master.gain.value = 0.0001;
+    master.connect(c.destination);
+    for (const partial of [
+      { frequency: 98, gain: 0.009 },
+      { frequency: 147.2, gain: 0.0055 },
+      { frequency: 294.6, gain: 0.0022 },
+    ]) {
+      const osc = c.createOscillator();
+      const gain = c.createGain();
+      osc.type = "sine";
+      osc.frequency.value = partial.frequency;
+      gain.gain.value = partial.gain;
+      osc.connect(gain);
+      gain.connect(master);
+      osc.start();
+      this.bedOscillators.push(osc);
+    }
+    this.bedGain = master;
+  }
+
+  private setBedLevel(value: number, seconds: number) {
+    if (!this.bedGain || !this.context) return;
+    const now = this.context.currentTime;
+    const current = Math.max(this.bedGain.gain.value, 0.0001);
+    this.bedGain.gain.cancelScheduledValues(now);
+    this.bedGain.gain.setValueAtTime(current, now);
+    this.bedGain.gain.exponentialRampToValueAtTime(
+      Math.max(value, 0.0001),
+      now + seconds,
+    );
   }
 }

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,32 +1,12 @@
 export class TerminalAudio {
-  private _enabled = false;
+  enabled = false;
   private context?: AudioContext;
-  private bedGain?: GainNode;
-  private bedOscillators: OscillatorNode[] = [];
-
-  get enabled() {
-    return this._enabled;
-  }
-
-  set enabled(value: boolean) {
-    this._enabled = value;
-    if (this.context) this.syncBed();
-  }
-
-  prime() {
-    try {
-      this.ensureContext();
-      this.syncBed();
-    } catch {
-      /* Audio is optional; the terminal remains fully interactive. */
-    }
-  }
-
   play(type: "tick" | "open" | "confirm" | "back" = "tick") {
-    if (!this._enabled) return;
+    if (!this.enabled) return;
     try {
-      const c = this.ensureContext();
-      this.syncBed();
+      this.context ??= new AudioContext();
+      const c = this.context;
+      if (c.state === "suspended") void c.resume();
       const osc = c.createOscillator(),
         gain = c.createGain();
       osc.type = "sine";
@@ -46,57 +26,5 @@ export class TerminalAudio {
     } catch {
       /* Audio is optional; the terminal remains fully interactive. */
     }
-  }
-
-  private ensureContext() {
-    this.context ??= new AudioContext();
-    if (this.context.state === "suspended") void this.context.resume();
-    return this.context;
-  }
-
-  private syncBed() {
-    if (!this.context) return;
-    if (!this._enabled) {
-      this.setBedLevel(0.0001, 0.4);
-      return;
-    }
-    this.ensureBed();
-    this.setBedLevel(1, 1.8);
-  }
-
-  private ensureBed() {
-    if (this.bedGain || !this.context) return;
-    const c = this.context;
-    const master = c.createGain();
-    master.gain.value = 0.0001;
-    master.connect(c.destination);
-    for (const partial of [
-      { frequency: 98, gain: 0.009 },
-      { frequency: 147.2, gain: 0.0055 },
-      { frequency: 294.6, gain: 0.0022 },
-    ]) {
-      const osc = c.createOscillator();
-      const gain = c.createGain();
-      osc.type = "sine";
-      osc.frequency.value = partial.frequency;
-      gain.gain.value = partial.gain;
-      osc.connect(gain);
-      gain.connect(master);
-      osc.start();
-      this.bedOscillators.push(osc);
-    }
-    this.bedGain = master;
-  }
-
-  private setBedLevel(value: number, seconds: number) {
-    if (!this.bedGain || !this.context) return;
-    const now = this.context.currentTime;
-    const current = Math.max(this.bedGain.gain.value, 0.0001);
-    this.bedGain.gain.cancelScheduledValues(now);
-    this.bedGain.gain.setValueAtTime(current, now);
-    this.bedGain.gain.exponentialRampToValueAtTime(
-      Math.max(value, 0.0001),
-      now + seconds,
-    );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,7 +107,7 @@ function readLocal<T>(key: string, fallback: T): T {
 }
 const saved = new Set<string>(readLocal<string[]>("rhine-saved", []));
 const prefs = readLocal("rhine-settings", {
-  sound: false,
+  sound: true,
   reduced: matchMedia("(prefers-reduced-motion: reduce)").matches,
   quality: true,
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,9 +136,6 @@ const selectedCode = createRollingNumber($("#selected-code"), codeOptions);
 const hoverCode = createRollingNumber($("#hover-code"), codeOptions);
 const audio = new TerminalAudio();
 audio.enabled = prefs.sound;
-const unlockAudio = () => audio.prime();
-window.addEventListener("pointerdown", unlockAudio);
-window.addEventListener("keydown", unlockAudio);
 let scene: ArchiveScene;
 let viewer: ModelViewer | undefined;
 const accessLog: { id: string; time: string }[] = [];
@@ -403,7 +400,7 @@ function renderResults() {
     `${String(results.length).padStart(2, "0")} RECORDS FOUND`;
 }
 function settingsMarkup() {
-  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面提示音与环境正弦铺垫</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="${publicUrl("fonts/MiSans-license.pdf")}" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
+  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面反馈音</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="${publicUrl("fonts/MiSans-license.pdf")}" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
 }
 
 document.addEventListener("input", (e) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import {
   fileLocation,
 } from "./data";
 import { TerminalAudio } from "./audio";
+import { publicUrl } from "./public-url";
 
 const $ = <T extends HTMLElement = HTMLElement>(selector: string) =>
   document.querySelector<T>(selector)!;
@@ -303,7 +304,7 @@ function renderDetail() {
   <dl class="metadata"><div><dt>DEPARTMENT / 科室</dt><dd>${r.department}</dd></div><div><dt>COLLECTION / 编目范围</dt><dd>${r.date}</dd></div><div><dt>RELATED / 相关人物</dt><dd>${r.lead}</dd></div><div><dt>STATUS / 状态</dt><dd><i></i>${r.clearance === "RESTRICTED" ? "目录访问" : "已归档 · 可读取"}</dd></div></dl>
   <div class="detail-tabs" role="tablist"><button class="active" role="tab" aria-selected="true" data-tab="overview">01 <span>概述</span></button><button role="tab" aria-selected="false" data-tab="notes">02 <span>研究记录</span></button><button role="tab" aria-selected="false" data-tab="history">03 <span>访问日志</span></button></div>
   <div id="tab-panel" class="tab-panel" role="tabpanel">${overview()}</div>
-  <div class="detail-actions"><button class="solid-button" data-action="bookmark">${saved.has(r.id) ? "− REMOVE FROM SAVED" : "＋ SAVE ARCHIVE"}<span>${saved.has(r.id) ? "已收藏" : "收藏档案"}</span></button><a class="export-button" href="/archives/RHINE-LAB-${r.id}.txt" download="RHINE-LAB-${r.id}.txt" aria-label="导出 ${r.id} 档案">EXPORT <span>↓</span></a></div>
+  <div class="detail-actions"><button class="solid-button" data-action="bookmark">${saved.has(r.id) ? "− REMOVE FROM SAVED" : "＋ SAVE ARCHIVE"}<span>${saved.has(r.id) ? "已收藏" : "收藏档案"}</span></button><a class="export-button" href="${publicUrl(`archives/RHINE-LAB-${r.id}.txt`)}" download="RHINE-LAB-${r.id}.txt" aria-label="导出 ${r.id} 档案">EXPORT <span>↓</span></a></div>
   <div class="detail-footnote"><a href="${r.source}" target="_blank" rel="noopener">设定参考 ↗</a><span>${String(selected + 1).padStart(3, "0")} / ${String(records.length).padStart(3, "0")}</span></div>`;
   $("#detail-content").setAttribute("tabindex", "-1");
   setTab(activeTab, false);
@@ -399,7 +400,7 @@ function renderResults() {
     `${String(results.length).padStart(2, "0")} RECORDS FOUND`;
 }
 function settingsMarkup() {
-  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面反馈音</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="/fonts/MiSans-license.pdf" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
+  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面反馈音</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="${publicUrl("fonts/MiSans-license.pdf")}" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
 }
 
 document.addEventListener("input", (e) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -136,6 +136,9 @@ const selectedCode = createRollingNumber($("#selected-code"), codeOptions);
 const hoverCode = createRollingNumber($("#hover-code"), codeOptions);
 const audio = new TerminalAudio();
 audio.enabled = prefs.sound;
+const unlockAudio = () => audio.prime();
+window.addEventListener("pointerdown", unlockAudio);
+window.addEventListener("keydown", unlockAudio);
 let scene: ArchiveScene;
 let viewer: ModelViewer | undefined;
 const accessLog: { id: string; time: string }[] = [];
@@ -400,7 +403,7 @@ function renderResults() {
     `${String(results.length).padStart(2, "0")} RECORDS FOUND`;
 }
 function settingsMarkup() {
-  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面反馈音</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="${publicUrl("fonts/MiSans-license.pdf")}" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
+  return `<h2>SYSTEM SETTINGS<small>终端偏好设置</small></h2><p class="settings-intro">JOYCE MOORE <span>·</span> SESSION AUTHORIZED</p><div class="settings-list"><label><div><strong>INTERFACE SOUND</strong><span>界面提示音与环境正弦铺垫</span></div><input type="checkbox" data-pref="sound" ${prefs.sound ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>REDUCED MOTION</strong><span>减少镜头移动和过渡动效</span></div><input type="checkbox" data-pref="reduced" ${prefs.reduced ? "checked" : ""}/><i class="toggle"></i></label><label><div><strong>HIGH QUALITY RENDERING</strong><span>环境遮蔽与高分辨率渲染</span></div><input type="checkbox" data-pref="quality" ${prefs.quality ? "checked" : ""}/><i class="toggle"></i></label></div><div class="settings-shortcuts"><span>KEYBOARD CONTROLS</span><p><kbd>←</kbd><kbd>→</kbd> 切列 <kbd>↑</kbd><kbd>↓</kbd> 选档 <kbd>ENTER</kbd> 读取 <kbd>/</kbd> 检索 <kbd>ESC</kbd> 返回</p></div><div class="settings-bottom"><button data-action="fullscreen">FULLSCREEN <span>↗</span></button><button data-action="restart">REINITIALIZE SYSTEM <span>↻</span></button></div><div class="modal-bottom"><span>ANALYSIS OS / 1.0 · 使用 MiSans 字体（小米） <a href="${publicUrl("fonts/MiSans-license.pdf")}" target="_blank" rel="noopener">字体许可</a></span><span>POWERED BY RHINE LAB</span></div>`;
 }
 
 document.addEventListener("input", (e) => {

--- a/src/public-url.ts
+++ b/src/public-url.ts
@@ -1,0 +1,3 @@
+export function publicUrl(path: string): string {
+  return `${import.meta.env.BASE_URL}${path.replace(/^\//, "")}`;
+}

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -23,6 +23,7 @@ import {
   type ArchiveNavigation,
 } from "./archive-loop";
 import { labelMarkSvg } from "./brand";
+import { publicUrl } from "./public-url";
 import {
   archiveWave,
   extraction,
@@ -181,7 +182,7 @@ export class ArchiveScene {
     this.labelMark.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(labelMarkSvg)}`;
     await this.labelMark.decode();
     const gltf = await new GLTFLoader().loadAsync(
-      "/assets/archive-cassette.glb",
+      publicUrl("assets/archive-cassette.glb"),
     );
     gltf.scene.updateMatrixWorld(true);
     const meshes: THREE.Mesh[] = [];
@@ -362,7 +363,7 @@ export class ArchiveScene {
   private assemblyTemplate?: Promise<THREE.Group>;
   async createAssemblyModel() {
     this.assemblyTemplate ??= new GLTFLoader()
-      .loadAsync("/assets/archive-assembly.glb")
+      .loadAsync(publicUrl("assets/archive-assembly.glb"))
       .then((gltf) => {
         gltf.scene.updateMatrixWorld(true);
         return gltf.scene;

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,36 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { defineConfig, type Plugin } from "vite";
+
+function pagesBase(): string {
+  const value = process.env.BASE_PATH;
+  if (!value || value === "/") return "/";
+  const withLeading = value.startsWith("/") ? value : `/${value}`;
+  return withLeading.endsWith("/") ? withLeading : `${withLeading}/`;
+}
+
+function prefixPublicAssetUrls(base: string): Plugin {
+  return {
+    name: "prefix-public-asset-urls",
+    transform(code, id) {
+      if (base === "/") return;
+      const file = id.split("?")[0].replaceAll("\\", "/");
+      if (!file.endsWith("/src/style.css")) return;
+      return code.replaceAll('url("/', `url("${base}`);
+    },
+  };
+}
+
+function writeNoJekyll(): Plugin {
+  return {
+    name: "write-nojekyll",
+    closeBundle() {
+      writeFileSync(resolve(import.meta.dirname, "dist/.nojekyll"), "");
+    },
+  };
+}
+
+export default defineConfig({
+  base: pagesBase(),
+  plugins: [prefixPublicAssetUrls(pagesBase()), writeNoJekyll()],
+});


### PR DESCRIPTION
## 用途

让仓库通过 GitHub Actions 构建静态站点，并部署到 GitHub Pages。访问者可以直接打开页面，不必下载项目或在本机启动 `npm run dev` / 静态服务。

本次同时修正了项目站子路径下的资源地址（字体、GLB 模型、档案导出），避免部署到 `https://<owner>.github.io/RhineLabUI/` 时出现 404。

## 上游如何使用

1. 合并本 PR 后，打开仓库 **Settings → Pages**，将 **Source** 设为 **GitHub Actions**。
2. 之后每次推送到 `main`，或在 **Actions** 中手动运行 **Deploy GitHub Pages**，都会重新构建并发布。
3. 发布地址为 `https://lbeilc.github.io/RhineLabUI/`。

本地开发不受影响：未设置 `BASE_PATH` 时仍从站点根路径 `/` 运行。若站点之后挂在自定义域名根路径，可设置 Actions 变量 `PAGES_BASE_PATH` 为 `/`。

## 验证

- 使用 `BASE_PATH=/RhineLabUI/` 完成本地生产构建与 `vite preview`，确认 `http://127.0.0.1:4173/RhineLabUI/` 可打开档案阵列，字体 / GLB / 档案文本均返回 200。
- 同一套工作流已推送到叉仓 `HKLHaoBin/RhineLabUI`，用于先跑通 Pages 部署。
